### PR TITLE
refactor: update tunnel command and improve authorization handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fix": "eslint --fix",
     "fix:client": "npm run fix -- src/client",
     "fix:server": "npm run fix -- src/server",
-    "tunnel": "wscat -H \"Authorization: Bearer $TOKEN\" -c ws://localhost:3000/api/tunnel"
+    "tunnel": "wscat -s \"Bearer $TOKEN\" -c ws://localhost:3000/api/tunnel"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.48.4",

--- a/src/server/routes/api/tunnel.ts
+++ b/src/server/routes/api/tunnel.ts
@@ -4,8 +4,10 @@ const plugin: FastifyPluginAsync = async server => {
   await server.register(import('@fastify/websocket'));
 
   server.addHook('onRequest', async request => {
-    if (!request.headers.authorization)
-      request.headers.authorization = request.headers['sec-websocket-protocol'];
+    const protocol = request.headers['sec-websocket-protocol'];
+    if (!request.headers.authorization && protocol)
+      request.headers.authorization = protocol;
+
     await server.authenticate()(request);
   });
 

--- a/src/server/routes/api/tunnel.ts
+++ b/src/server/routes/api/tunnel.ts
@@ -3,7 +3,11 @@ import {FastifyPluginAsync} from 'fastify';
 const plugin: FastifyPluginAsync = async server => {
   await server.register(import('@fastify/websocket'));
 
-  server.addHook('onRequest', server.authenticate());
+  server.addHook('onRequest', async request => {
+    if (!request.headers.authorization)
+      request.headers.authorization = request.headers['sec-websocket-protocol'];
+    await server.authenticate()(request);
+  });
 
   server.get('/tunnel', {websocket: true}, server.clients.routeHandler);
 };


### PR DESCRIPTION
This pull request makes updates to improve WebSocket tunneling functionality and authentication handling. The most important changes include modifying the `tunnel` npm script to use the correct WebSocket subprotocol flag and updating the server's `onRequest` hook to handle WebSocket-specific headers for authentication.

### Updates to WebSocket tunneling:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28): Updated the `tunnel` script to use the `-s` flag for specifying the WebSocket subprotocol instead of the `-H` flag for headers. This aligns with the correct usage for WebSocket connections.

### Improvements to authentication handling:

* [`src/server/routes/api/tunnel.ts`](diffhunk://#diff-1312c7a30e74c2ea0f6b380d842ab60f1fbf398ac6216d10f0965572d6161668L6-R10): Modified the `onRequest` hook to check for the `sec-websocket-protocol` header and assign it to the `authorization` header if missing. This ensures proper authentication for WebSocket requests.