### PR TITLE
fix: update authorization header format in tunnel route

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fix": "eslint --fix",
     "fix:client": "npm run fix -- src/client",
     "fix:server": "npm run fix -- src/server",
-    "tunnel": "wscat -s \"Bearer $TOKEN\" -c ws://localhost:3000/api/tunnel"
+    "tunnel": "wscat -s \"$TOKEN\" -c ws://localhost:3000/api/tunnel"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.48.4",

--- a/src/server/routes/api/tunnel.ts
+++ b/src/server/routes/api/tunnel.ts
@@ -6,7 +6,7 @@ const plugin: FastifyPluginAsync = async server => {
   server.addHook('onRequest', async request => {
     const protocol = request.headers['sec-websocket-protocol'];
     if (!request.headers.authorization && protocol)
-      request.headers.authorization = protocol;
+      request.headers.authorization = `Bearer ${protocol}`;
 
     await server.authenticate()(request);
   });


### PR DESCRIPTION
This pull request includes two changes to improve the handling of WebSocket tunnel authentication. The changes ensure that the `Bearer` token is consistently applied in both the `package.json` script and the server-side WebSocket request handling.

### Authentication improvements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28): Updated the `tunnel` script to ensure the `$TOKEN` environment variable is passed correctly without including the `Bearer` prefix explicitly.
* [`src/server/routes/api/tunnel.ts`](diffhunk://#diff-1312c7a30e74c2ea0f6b380d842ab60f1fbf398ac6216d10f0965572d6161668L9-R9): Modified the `onRequest` hook to prepend `Bearer` to the `sec-websocket-protocol` header when setting the `authorization` header, ensuring consistent authentication formatting.