### PR TITLE
Add success message to leaveMatchmaking function

### DIFF
--- a/src/server/tunnel/leaveMatchmaking.ts
+++ b/src/server/tunnel/leaveMatchmaking.ts
@@ -7,5 +7,10 @@ export default function leaveMatchmaking(
   message: {type: 'leaveMatchmaking'},
 ) {
   server.leaveMatchmaking(client.socket);
+  server.clients.sendUser(client.userID, {
+    type: 'success',
+    origin: 'leaveMatchmaking',
+  });
+
   void message;
 }


### PR DESCRIPTION
This pull request updates the `leaveMatchmaking` handler to provide explicit feedback to the user when they leave matchmaking. Now, after processing the leave request, the server sends a success message to the user to confirm the action.

User feedback improvement:

* [`src/server/tunnel/leaveMatchmaking.ts`](diffhunk://#diff-710e55b61a6705e0b1434c1759d053f4ffb9f63b00ebbb44994f196c62351fbcR10-R14): After a user leaves matchmaking, the server now sends a success message with type `'success'` and origin `'leaveMatchmaking'` to the user, providing immediate feedback on the action.