### PR TITLE
Remove confirmPassword field from account edit API

### DIFF
--- a/docs/bruno/API/Account/Edit account.bru
+++ b/docs/bruno/API/Account/Edit account.bru
@@ -15,6 +15,5 @@ body:json {
     "username": "deydoux",
     "oldPassword": "Hello World42",
     "password": "Hello World42",
-    "confirmPassword": "Hello World42"
   }
 }

--- a/src/server/routes/api/account/patch.ts
+++ b/src/server/routes/api/account/patch.ts
@@ -11,7 +11,6 @@ const schema = {
     properties: {
       username,
       password,
-      confirmPassword: {type: 'string'},
       oldPassword: {type: 'string'},
     },
   } as const,
@@ -19,12 +18,7 @@ const schema = {
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async server => {
   server.patch('/', {schema}, async (request, reply) => {
-    const {username, password, confirmPassword, oldPassword} = request.body;
-    if (password !== confirmPassword)
-      throw {
-        ...errorCodes.FST_ERR_VALIDATION('Password mismatch'),
-        field: 'confirmPassword',
-      };
+    const {username, password, oldPassword} = request.body;
 
     const {id} = request.user;
     const columns = [];


### PR DESCRIPTION
This pull request simplifies the account editing API by removing the requirement for users to provide a `confirmPassword` field when updating their account information. The related validation logic and schema property are also removed to streamline the password update process.

**API schema and validation simplification:**

* Removed the `confirmPassword` field from the JSON body in the account edit API request example (`Edit account.bru`).
* Removed the `confirmPassword` property from the API schema and deleted the password confirmation validation logic in `patch.ts`. Now, only `password` and `oldPassword` are required for password updates.