### PR TITLE
Ensure hasAvatar is set as a boolean before sending user data

### DIFF
--- a/src/server/routes/api/account/get.ts
+++ b/src/server/routes/api/account/get.ts
@@ -15,6 +15,7 @@ const plugin: FastifyPluginAsync = async server => {
 
     if (!user) return reply.notFound('Account not found');
 
+    user.hasAvatar = Boolean(user.has_avatar);
     user.totp = Boolean(user.totp);
     if (user.passwordEditedAt)
       user.passwordEditedAt = new Date(user.passwordEditedAt * 1000);


### PR DESCRIPTION
This pull request makes a minor update to the account API route to ensure the `hasAvatar` property on the `user` object is always a boolean. This improves type consistency in the API response.

* Ensure `user.hasAvatar` is set to a boolean value based on `user.has_avatar` in the `get.ts` account API route.