### PR TITLE
feat: add mention support to general messages

### DIFF
--- a/docs/WebSocket/README.md
+++ b/docs/WebSocket/README.md
@@ -165,7 +165,8 @@ Received when a general message is sent
     "username": "user123",
     "avatar": "/static/default_avatar.webp"
   },
-  "content": "Hello, World!"
+  "content": "Hello, World!",
+  "mention": false
 }
 ```
 

--- a/src/server/routes/api/chats/general/post.ts
+++ b/src/server/routes/api/chats/general/post.ts
@@ -27,6 +27,28 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async server => {
       VALUES(${user.id}, ${content})
     `);
 
+    const usernames =
+      content
+        .match(/(?<=@)[a-zA-Z0-9_]+/g)
+        ?.map(username => username.toLowerCase()) || [];
+
+    let mentionedIDs: number[] = [];
+    if (usernames.length > 0) {
+      const query = SQL`
+        SELECT id
+        FROM users
+        WHERE lower(username) IN (`;
+
+      for (const [index, username] of usernames.entries()) {
+        if (index !== 0) query.append(SQL`, `);
+        query.append(SQL`${username}`);
+      }
+
+      query.append(SQL`)`);
+
+      mentionedIDs = (await server.db.all(query)).map(row => row.id);
+    }
+
     const sender = await server.db.get(SQL`
       SELECT id, username, has_avatar, avatar_version
       FROM users
@@ -47,11 +69,20 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async server => {
     ).map(row => row.id);
 
     ignoreIDs.push(user.id);
+    mentionedIDs = mentionedIDs.filter(id => !ignoreIDs.includes(id));
+    ignoreIDs.push(...mentionedIDs);
 
-    server.clients.broadcast(
-      {type: 'generalMessage', sender, content},
-      ignoreIDs,
-    );
+    const message = {
+      type: 'generalMessage' as const,
+      sender,
+      content,
+      mention: true,
+    };
+
+    for (const id of mentionedIDs) server.clients.sendUser(id, message);
+
+    message.mention = false;
+    server.clients.broadcast(message, ignoreIDs);
   });
 };
 

--- a/src/server/types/Clients.d.ts
+++ b/src/server/types/Clients.d.ts
@@ -22,7 +22,7 @@ type ClientTunnelMessage =
 
 type ServerTunnelMessage =
   | {
-      type: 'directMessage' | 'generalMessage';
+      type: 'directMessage';
       sender: unknown;
       content: string;
     }
@@ -34,6 +34,12 @@ type ServerTunnelMessage =
       type: 'friendRequest' | 'friendRequestAccepted';
       user: unknown;
       relationship?: number;
+    }
+  | {
+      type: 'generalMessage';
+      sender: unknown;
+      content: string;
+      mention: boolean;
     }
   | {type: 'hotReload'}
   | {


### PR DESCRIPTION
This pull request enhances the general chat message handling to support user mentions. Now, when a message includes `@username` mentions, the server identifies mentioned users and sends them a special notification. The broadcast logic is also updated to ensure mentioned users receive a distinct message, and all other users get the standard message.

**User mention detection and notification:**

* Added logic to parse `@username` mentions from the message content, query the database for matching user IDs, and filter out the sender and already-ignored users. Mentioned users now receive a direct message with `mention: true`. (`src/server/routes/api/chats/general/post.ts`) [[1]](diffhunk://#diff-8a28697c52540fbff7656d00216b46dcd40fe87f0ca00924f4cc01d2dfc9db05R30-R51) [[2]](diffhunk://#diff-8a28697c52540fbff7656d00216b46dcd40fe87f0ca00924f4cc01d2dfc9db05R72-R85)

**Message structure update:**

* Updated the message payload to include a `mention` boolean field, allowing clients to distinguish between general and mention notifications. (`docs/WebSocket/README.md`, `src/server/routes/api/chats/general/post.ts`) [[1]](diffhunk://#diff-50f8a58f00f821245a06e75afe67c81e9e2adc7334490f716f79a1572c04faa8L168-R169) [[2]](diffhunk://#diff-8a28697c52540fbff7656d00216b46dcd40fe87f0ca00924f4cc01d2dfc9db05R72-R85)