### PR TITLE
fix: update inviterID to targetID in matchmaking documentation

### DIFF
--- a/docs/WebSocket/README.md
+++ b/docs/WebSocket/README.md
@@ -31,7 +31,7 @@ Sent to join the matchmaking queue
   "type": "joinMatchmaking",
   "game": "race",
   "mode": "casual",
-  "inviterID": 2
+  "targetID": 2
 }
 ```
 

--- a/docs/WebSocket/gameInvite.md
+++ b/docs/WebSocket/gameInvite.md
@@ -7,14 +7,14 @@ sequenceDiagram
   actor q as Quentin (ID 2)
 
   m ->> s: joinMatchmaking
-  Note right of m: {game: 'pong', mode: 'casual', inviterID: 2}
+  Note right of m: {game: 'pong', mode: 'casual', targetID: 2}
   s -->> m: success
   Note left of s: {origin: 'joinMatchmaking'}
   s ->> q: gameInvite
   Note right of s: {game: 'pong', user: {id: 1, ...}}
 
   q ->> s: joinMatchmaking
-  Note left of q: {game: 'pong', mode: 'casual', inviterID: 1}
+  Note left of q: {game: 'pong', mode: 'casual', targetID: 1}
   s -->> q: success
   Note right of s: {origin: 'joinMatchmaking'}
 


### PR DESCRIPTION
This pull request updates the naming of a key field in the matchmaking WebSocket documentation to improve clarity and consistency. The field previously named `inviterID` has been renamed to `targetID` in relevant documentation files.

Documentation updates:

* Renamed the `inviterID` field to `targetID` in the example payload for the `joinMatchmaking` event in `docs/WebSocket/README.md`.
* Updated the sequence diagram in `docs/WebSocket/gameInvite.md` to use `targetID` instead of `inviterID` in all relevant notes.