### PR TITLE
fix: set proxy_read_timeout for WebSocket handling

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,14 +39,15 @@ http {
 		}
 
 		location /api {
-			proxy_http_version	1.1;
 			proxy_cache_bypass	$http_upgrade;
-			proxy_set_header	Upgrade $http_upgrade;
+			proxy_http_version	1.1;
+			proxy_read_timeout	24h;
 			proxy_set_header	Connection 'upgrade';
 			proxy_set_header	Host $host;
-			proxy_set_header	X-Real-IP $remote_addr;
+			proxy_set_header	Upgrade $http_upgrade;
 			proxy_set_header	X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header	X-Forwarded-Proto $scheme;
+			proxy_set_header	X-Real-IP $remote_addr;
 
 			proxy_pass	http://app:3000/api;
 		}


### PR DESCRIPTION
This pull request makes minor adjustments to the `nginx.conf` file to improve the configuration for the `/api` location. The changes mainly involve reordering and adding proxy headers and increasing the read timeout for API requests.

Key configuration improvements:

* Increased the `proxy_read_timeout` for `/api` requests to 24 hours to support long-running connections.
* Reordered and clarified proxy headers for better readability and to ensure correct header values are set, including moving `proxy_set_header Upgrade` after `proxy_set_header Connection` and restoring `proxy_set_header X-Real-IP`.