### PR TITLE
fix: update match result terminology from 'draw' to 'forfeit'

### DIFF
--- a/docs/WebSocket/README.md
+++ b/docs/WebSocket/README.md
@@ -193,7 +193,7 @@ Received when a match ends
 {
   "type": "matchEnd",
   "winner": 1,
-  "result": "draw",
+  "result": "forfeit",
   "eloChange": 20
 }
 ```

--- a/docs/WebSocket/match.md
+++ b/docs/WebSocket/match.md
@@ -39,7 +39,7 @@ sequenceDiagram
   alt Quentin disconnects
     s --x q: *socket closed*
     s ->> m: matchEnd
-    Note left of s: {winner: 1, result: 'draw'}
+    Note left of s: {winner: 1, result: 'forfeit'}
 
   else Mathy scores
     m ->> s: score

--- a/migrations/001-initial.sql
+++ b/migrations/001-initial.sql
@@ -65,7 +65,7 @@ CREATE TABLE matches(
 
   CHECK(game IN ('pong', 'race')),
   CHECK(mode IN ('casual', 'ranked')),
-  CHECK(result IN ('draw', 'tie'))
+  CHECK(result IN ('forfeit', 'tie'))
 );
 
 CREATE INDEX idx_matches_winner_id_loser_id ON matches(winner_id, loser_id);

--- a/src/server/lib/Match.ts
+++ b/src/server/lib/Match.ts
@@ -33,7 +33,7 @@ export default abstract class Match {
   private readonly lock;
 
   protected players;
-  protected result?: 'draw' | 'tie';
+  protected result?: 'forfeit' | 'tie';
   protected unlock = () => undefined;
   protected winner?: Player;
 
@@ -164,7 +164,7 @@ export default abstract class Match {
   }
 
   private handleClose(opponent: Player) {
-    this.result = 'draw';
+    this.result = 'forfeit';
     this.winner = opponent;
     this.unlock();
   }

--- a/src/server/types/Clients.d.ts
+++ b/src/server/types/Clients.d.ts
@@ -55,7 +55,7 @@ type ServerTunnelMessage =
   | {
       type: 'matchEnd';
       winner: number;
-      result?: 'draw' | 'tie';
+      result?: 'forfeit' | 'tie';
       eloChange?: number;
     }
   | {


### PR DESCRIPTION
This pull request updates the way match results are represented across the codebase and documentation, replacing the term 'draw' with 'forfeit' to more accurately reflect matches that end due to a player disconnecting. The changes ensure consistency between the backend logic, database schema, and documentation.

**Match result terminology update:**

* Changed the possible value for match results from `'draw'` to `'forfeit'` in the `result` field of the `Match` class, affecting both the type definition and the logic for handling player disconnects (`src/server/lib/Match.ts`). [[1]](diffhunk://#diff-3aa629d1467dada37f9630ab2015794175ef5ee468297e800f4f5367d2b33957L36-R36) [[2]](diffhunk://#diff-3aa629d1467dada37f9630ab2015794175ef5ee468297e800f4f5367d2b33957L167-R167)
* Updated the database schema to allow `'forfeit'` instead of `'draw'` as a valid match result in the `matches` table (`migrations/001-initial.sql`).

**Documentation updates:**

* Updated the WebSocket event documentation to use `'forfeit'` instead of `'draw'` for match end scenarios (`docs/WebSocket/README.md`).
* Modified the WebSocket match sequence diagram to reflect the new `'forfeit'` result in disconnect scenarios (`docs/WebSocket/match.md`).