### PR TITLE
Add angle generation for match and round events

### DIFF
--- a/docs/WebSocket/gameInvite.md
+++ b/docs/WebSocket/gameInvite.md
@@ -20,5 +20,5 @@ sequenceDiagram
 
   s ->> m: matchStart
   s ->> q: matchStart
-  Note over s: {game: 'pong', ranked: false, block: false, players: [...]}<br><br> players:<br>{id: 1, username: 'mapale', avatar: '/api/users/1/avatar?v=1'}<br>{id: 2, username: 'quteriss', avatar: '/api/users/2/avatar?v=1'}
+  Note over s: {game: 'pong', ranked: false, block: false, players: [...], dx: -0.19, dy: 0.98}<br><br> players:<br>{id: 1, username: 'mapale', avatar: '/api/users/1/avatar?v=1'}<br>{id: 2, username: 'quteriss', avatar: '/api/users/2/avatar?v=1'}
 ```

--- a/docs/WebSocket/match.md
+++ b/docs/WebSocket/match.md
@@ -23,7 +23,7 @@ sequenceDiagram
 
   s ->> m: matchStart
   s ->> q: matchStart
-  Note over s: {game: 'pong', ranked: false, block: false, players: [...]}<br><br> players:<br>{id: 1, username: 'mapale', avatar: '/api/users/1/avatar?v=1'}<br>{id: 2, username: 'quteriss', avatar: '/api/users/2/avatar?v=1'}
+  Note over s: {game: 'pong', ranked: false, block: false, players: [...], dx: 0.94, dy: 0.34}<br><br> players:<br>{id: 1, username: 'mapale', avatar: '/api/users/1/avatar?v=1'}<br>{id: 2, username: 'quteriss', avatar: '/api/users/2/avatar?v=1'}
 
   q ->> s: joinMatchmaking
   s -->> q: error
@@ -50,6 +50,7 @@ sequenceDiagram
     alt New round
       s ->> m: round
       s ->> q: round
+      Note over s: {dx: 0.74, dy: -0.68}
     else Mathy wins
       s ->> m: matchEnd
       s ->> q: matchEnd

--- a/src/server/lib/Match.ts
+++ b/src/server/lib/Match.ts
@@ -86,6 +86,13 @@ export default abstract class Match {
     });
   }
 
+  protected static generateAngle() {
+    return (
+      Math.random() * (Math.PI / 3) +
+      Math.round(Math.random() * 3) * (Math.PI / 2)
+    );
+  }
+
   get game() {
     return this._game;
   }
@@ -273,6 +280,8 @@ export default abstract class Match {
   }
 
   public async start() {
+    const angle = Match.generateAngle();
+
     this.send({
       type: 'matchStart',
       game: this._game,
@@ -284,6 +293,8 @@ export default abstract class Match {
         avatar: player.avatar,
         elo: player.elo,
       })),
+      dx: Math.cos(angle),
+      dy: Math.sin(angle),
     });
 
     await this.lock;

--- a/src/server/lib/PongMatch.ts
+++ b/src/server/lib/PongMatch.ts
@@ -14,6 +14,12 @@ export default class PongMatch extends Match {
       return this.unlock();
     }
 
-    this.send({type: 'round'});
+    const angle = Match.generateAngle();
+
+    this.send({
+      type: 'round',
+      dx: Math.cos(angle),
+      dy: Math.sin(angle),
+    });
   }
 }

--- a/src/server/types/Clients.d.ts
+++ b/src/server/types/Clients.d.ts
@@ -64,8 +64,14 @@ type ServerTunnelMessage =
       ranked: boolean;
       block: boolean;
       players: unknown[];
+      dx: number;
+      dy: number;
     }
-  | {type: 'round'}
+  | {
+      type: 'round';
+      dx: number;
+      dy: number;
+    }
   | {
       type: 'success';
       origin: string;


### PR DESCRIPTION
This pull request updates the WebSocket match flow to randomize and communicate the initial direction of the ball in Pong matches. It introduces a new method to generate a random angle, which is then used to calculate and send the initial `dx` and `dy` (directional x and y velocities) during match and round starts. The documentation is also updated to reflect these changes.

**Gameplay logic improvements:**

* Added a static `generateAngle` method to `Match` to randomize the ball's starting angle, and used it in both the `start` method of `Match` and the `round` method of `PongMatch` to set initial direction. (`src/server/lib/Match.ts`, `src/server/lib/PongMatch.ts`) [[1]](diffhunk://#diff-3aa629d1467dada37f9630ab2015794175ef5ee468297e800f4f5367d2b33957R89-R95) [[2]](diffhunk://#diff-3aa629d1467dada37f9630ab2015794175ef5ee468297e800f4f5367d2b33957R283-R284) [[3]](diffhunk://#diff-2a04bc7ae741d94f450522b36c0c0d4a8b152d421d8d8f8590f9ed91832f24b6L17-R23)

* Updated the match start and round messages to include the calculated `dx` and `dy` values, communicating the ball's initial direction to clients. (`src/server/lib/Match.ts`, `src/server/lib/PongMatch.ts`) [[1]](diffhunk://#diff-3aa629d1467dada37f9630ab2015794175ef5ee468297e800f4f5367d2b33957R296-R297) [[2]](diffhunk://#diff-2a04bc7ae741d94f450522b36c0c0d4a8b152d421d8d8f8590f9ed91832f24b6L17-R23)

**Documentation updates:**

* Updated `docs/WebSocket/gameInvite.md` and `docs/WebSocket/match.md` to show the new `dx` and `dy` fields in example payloads for `matchStart` and `round` events. [[1]](diffhunk://#diff-e27afcc2dd9ce7f809d36191f361260f5daee1d4411c4d5110f2e7fe95e92103L23-R23) [[2]](diffhunk://#diff-04b947f15b8cd2b833810d94a21a3ecc436bebd7a9aef1b8ba356f04e9272f2eL26-R26) [[3]](diffhunk://#diff-04b947f15b8cd2b833810d94a21a3ecc436bebd7a9aef1b8ba356f04e9272f2eR53)