### PR TITLE
Register static file serving for avatar images in production

### DIFF
--- a/src/server/routes/api/users/:id/avatar/get.ts
+++ b/src/server/routes/api/users/:id/avatar/get.ts
@@ -2,6 +2,11 @@ import {FastifyPluginAsyncJsonSchemaToTs} from '@fastify/type-provider-json-sche
 import {idParamsSchema as schema} from '#lib/schemas';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async server => {
+  if (server.prod)
+    await server.register(import('@fastify/static'), {
+      root: server.paths.avatars,
+    });
+
   server.setNotFoundHandler((_, reply) =>
     reply.redirect('/static/default_avatar.webp', 302),
   );


### PR DESCRIPTION
This pull request introduces a conditional registration of the `@fastify/static` plugin for serving avatar files in production environments. It also ensures that missing avatar requests are redirected to a default image.

Enhancements to avatar serving:

* [`src/server/routes/api/users/:id/avatar/get.ts`](diffhunk://#diff-3f40d05473da1d07099eef7c23a6b6e178a759ffc0d18d0b2a4581907e8a4030R5-R9): Registers the `@fastify/static` plugin with the avatars directory as the root only in production, improving static file serving for user avatars.
* [`src/server/routes/api/users/:id/avatar/get.ts`](diffhunk://#diff-3f40d05473da1d07099eef7c23a6b6e178a759ffc0d18d0b2a4581907e8a4030R5-R9): Keeps the not-found handler to redirect missing avatar requests to `/static/default_avatar.webp`.