### PR TITLE
fix: Nullify passwordEditedAt when no password set

### DIFF
--- a/src/server/routes/api/account/get.ts
+++ b/src/server/routes/api/account/get.ts
@@ -1,13 +1,14 @@
 import {FastifyPluginAsync} from 'fastify';
 import SQL from 'sql-template-strings';
 import serializeUserAvatar from '#lib/serializeUserAvatar';
+import {password} from '#lib/schemas';
 
 const plugin: FastifyPluginAsync = async server => {
   server.get('/', async (request, reply) => {
     const {id} = request.user;
 
     const user = await server.db.get(SQL`
-      SELECT id, username, password_edited_at AS passwordEditedAt,
+      SELECT id, username, password, password_edited_at AS passwordEditedAt,
              totp_enabled AS totp, has_avatar, avatar_version
       FROM users
       WHERE id = ${id}
@@ -17,8 +18,10 @@ const plugin: FastifyPluginAsync = async server => {
 
     user.hasAvatar = Boolean(user.has_avatar);
     user.totp = Boolean(user.totp);
-    if (user.passwordEditedAt)
-      user.passwordEditedAt = new Date(user.passwordEditedAt * 1000);
+    console.log(user.password, !user.password);
+    if (!user.password) user.passwordEditedAt = null;
+    else user.passwordEditedAt = new Date(user.passwordEditedAt * 1000);
+    delete user.password;
     serializeUserAvatar(user);
 
     return reply.send(user);

--- a/src/server/routes/api/account/get.ts
+++ b/src/server/routes/api/account/get.ts
@@ -1,7 +1,6 @@
 import {FastifyPluginAsync} from 'fastify';
 import SQL from 'sql-template-strings';
 import serializeUserAvatar from '#lib/serializeUserAvatar';
-import {password} from '#lib/schemas';
 
 const plugin: FastifyPluginAsync = async server => {
   server.get('/', async (request, reply) => {
@@ -18,7 +17,6 @@ const plugin: FastifyPluginAsync = async server => {
 
     user.hasAvatar = Boolean(user.has_avatar);
     user.totp = Boolean(user.totp);
-    console.log(user.password, !user.password);
     if (!user.password) user.passwordEditedAt = null;
     else user.passwordEditedAt = new Date(user.passwordEditedAt * 1000);
     delete user.password;


### PR DESCRIPTION
This pull request updates the account API endpoint to improve how password-related fields are handled in user data responses. The main changes ensure that sensitive password information is not exposed and that the `passwordEditedAt` field is only set when appropriate.

Improvements to password handling:

* The SQL query now selects the `password` field so it can be checked in the response logic, but the field is removed before sending the response to avoid exposing sensitive data. [[1]](diffhunk://#diff-7e024d9562e0b77b64aa578771c3b4cedeabab86c2990aecd640c5c205a914f0R4-R11) [[2]](diffhunk://#diff-7e024d9562e0b77b64aa578771c3b4cedeabab86c2990aecd640c5c205a914f0L20-R24)
* The logic for setting `passwordEditedAt` has been updated: if the user does not have a password, `passwordEditedAt` is set to `null`; otherwise, it is converted to a JavaScript `Date` object.