### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,16 +30,16 @@
         "ua-parser-js": "^2.0.5"
       },
       "devDependencies": {
-        "@dotenvx/dotenvx": "^1.49.0",
-        "@eslint/js": "^9.35.0",
+        "@dotenvx/dotenvx": "^1.50.1",
+        "@eslint/js": "^9.36.0",
         "@tailwindcss/vite": "^4.1.13",
         "@types/bcrypt": "^6.0.0",
-        "@types/node": "^24.4.0",
+        "@types/node": "^24.5.2",
         "@types/qrcode": "^1.5.5",
         "@types/sqlite3": "^5.1.0",
         "@types/ws": "^8.18.1",
         "concurrently": "^9.2.1",
-        "eslint": "^9.35.0",
+        "eslint": "^9.36.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "nodemon": "^3.1.10",
@@ -48,7 +48,7 @@
         "tailwindcss": "^4.1.13",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.43.0",
-        "vite": "^7.1.5"
+        "vite": "^7.1.7"
       }
     },
     "node_modules/@babel/runtime": {
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.49.0.tgz",
-      "integrity": "sha512-M1cyP6YstFQCjih54SAxCqHLMMi8QqV8tenpgGE48RTXWD7vfMYJiw/6xcCDpS2h28AcLpTsFCZA863Ge9yxzA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.50.1.tgz",
+      "integrity": "sha512-0hymEluMsQwwukPcnF7IjhmgA6j2jaZtfOtFafOgeZi24BJHY1lHlqwD7dO46KF9WCfpBB3J5uAEwlgBOzAAxg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -696,9 +696,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2463,13 +2463,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
-      "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.11.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3880,7 +3880,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -8255,9 +8255,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.11.0.tgz",
-      "integrity": "sha512-kt1ZriHTi7MU+Z/r9DOdAI3ONdaR3M3csEaRc6ewa4f4dTvX4cQCbJ4NkEn0ohE4hHtq85+PhPSTY+pO/1PwgA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8307,9 +8307,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
+      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "fix:server": "npm run fix -- src/server"
   },
   "devDependencies": {
-    "@dotenvx/dotenvx": "^1.49.0",
-    "@eslint/js": "^9.35.0",
+    "@dotenvx/dotenvx": "^1.50.1",
+    "@eslint/js": "^9.36.0",
     "@tailwindcss/vite": "^4.1.13",
     "@types/bcrypt": "^6.0.0",
-    "@types/node": "^24.4.0",
+    "@types/node": "^24.5.2",
     "@types/qrcode": "^1.5.5",
     "@types/sqlite3": "^5.1.0",
     "@types/ws": "^8.18.1",
     "concurrently": "^9.2.1",
-    "eslint": "^9.35.0",
+    "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "nodemon": "^3.1.10",
@@ -45,7 +45,7 @@
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.43.0",
-    "vite": "^7.1.5"
+    "vite": "^7.1.7"
   },
   "dependencies": {
     "@fastify/autoload": "^6.3.1",


### PR DESCRIPTION
This pull request updates several development dependencies in the `package.json` file to their latest versions, ensuring the project uses the most recent bug fixes and features.

Dependency version upgrades:

* Upgraded `@dotenvx/dotenvx` from `^1.49.0` to `^1.50.1` to incorporate the latest improvements and fixes.
* Upgraded `@eslint/js` and `eslint` from `^9.35.0` to `^9.36.0` for enhanced linting capabilities and bug fixes.
* Updated `@types/node` from `^24.4.0` to `^24.5.2` for improved Node.js type definitions.
* Upgraded `vite` from `^7.1.5` to `^7.1.7` for the latest build tool features and fixes.