### PR TITLE
feat: add avatar retrieval and encoding for user account dump

### DIFF
--- a/src/client/containers/settings/rgpd.ts
+++ b/src/client/containers/settings/rgpd.ts
@@ -43,7 +43,7 @@ export class RGPD {
 
       const {user} = Store.getInstance().getState();
       if (!user) throw new Error('User is undefined');
-      downloadResponse(`KittyPong-${user.username}-data.txt`, response);
+      downloadResponse(`KittyPong-${user.username}-data.json`, response);
     } catch (error) {
       Toastify.error('An error occured while downloading data');
       console.error(error);

--- a/src/server/routes/api/account/dump/get.ts
+++ b/src/server/routes/api/account/dump/get.ts
@@ -1,5 +1,7 @@
+import {access, constants, readFile} from 'node:fs/promises';
 import {FastifyPluginAsync} from 'fastify';
 import SQL from 'sql-template-strings';
+import {join} from 'node:path';
 
 const plugin: FastifyPluginAsync = async server => {
   server.get('/', async (request, reply) => {
@@ -51,6 +53,18 @@ const plugin: FastifyPluginAsync = async server => {
       FROM elo
       WHERE user_id = ${id}
     `);
+
+    if (user.has_avatar) {
+      const avatarPath = join(server.paths.avatars, `${id}.webp`);
+
+      try {
+        await access(avatarPath, constants.R_OK);
+        const file = await readFile(avatarPath);
+        user.avatar = `data:image/webp;base64,${file.toString('base64')}`;
+      } catch {
+        void 0;
+      }
+    }
 
     return reply
       .header(

--- a/src/server/routes/api/account/dump/get.ts
+++ b/src/server/routes/api/account/dump/get.ts
@@ -1,7 +1,7 @@
-import {access, constants, readFile} from 'node:fs/promises';
 import {FastifyPluginAsync} from 'fastify';
 import SQL from 'sql-template-strings';
 import {join} from 'node:path';
+import {readFile} from 'node:fs/promises';
 
 const plugin: FastifyPluginAsync = async server => {
   server.get('/', async (request, reply) => {
@@ -58,7 +58,6 @@ const plugin: FastifyPluginAsync = async server => {
       const avatarPath = join(server.paths.avatars, `${id}.webp`);
 
       try {
-        await access(avatarPath, constants.R_OK);
         const file = await readFile(avatarPath);
         user.avatar = `data:image/webp;base64,${file.toString('base64')}`;
       } catch {

--- a/src/server/routes/api/users/:id/avatar/get.ts
+++ b/src/server/routes/api/users/:id/avatar/get.ts
@@ -11,6 +11,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async server => {
     reply.redirect('/static/default_avatar.webp', 302),
   );
 
+  server.setErrorHandler((_, _request, reply) =>
+    reply.redirect('/static/default_avatar.webp', 302),
+  );
+
   server.get('/', {schema}, async (request, reply) => {
     const {id} = request.params;
     return reply.sendFile(`${id}.webp`, server.paths.avatars);


### PR DESCRIPTION
This pull request updates the account dump API endpoint to include an inline avatar image for users who have an avatar. The code now checks for the user's avatar file, reads it if available, and attaches it as a base64-encoded data URI to the response.

Enhancement to account dump API:

* The endpoint now checks if a user has an avatar (`has_avatar`), and if so, attempts to read the corresponding `.webp` file from the avatars directory. If the file is found and readable, it is encoded in base64 and added to the user object as a data URI (`user.avatar`).
* Added imports for `access`, `constants`, and `readFile` from `node:fs/promises`, and `join` from `node:path` to support the new avatar handling logic.