### PR TITLE
fix: update tournament match end message structure to include winnerID and participants

### DIFF
--- a/docs/WebSocket/README.md
+++ b/docs/WebSocket/README.md
@@ -327,13 +327,13 @@ Received when a tournament match ends
   "type": "tournamentMatchEnd",
   "roundID": 1,
   "nextRoundID": 2,
-  "winner": {
+  "winnerID": 1,
+  "participants": [{
     "id": 1,
     "username": "user123",
     "avatar": "/static/default_avatar.webp",
     "score": 3
-  },
-  "losers": [{
+  }, {
     "id": 2,
     "username": "user456",
     "avatar": "/static/default_avatar.webp",

--- a/docs/WebSocket/tournament.md
+++ b/docs/WebSocket/tournament.md
@@ -72,7 +72,7 @@ sequenceDiagram
   s ->> q: tournamentMatchEnd
   s ->> m: tournamentMatchEnd
   s ->> d: tournamentMatchEnd
-  Note left of s: {roundID: 3, nextRoundID: 1, winner: {id: 3, ...}, result: 'empty'}
+  Note left of s: {roundID: 3, nextRoundID: 1, winnerID: 3, participants: [...], result: 'empty'}
   s ->> s: *5sec*
   s ->> d: matchStart
   s ->>- m: matchStart
@@ -85,7 +85,7 @@ sequenceDiagram
   s ->> q: tournamentMatchEnd
   s ->> m: tournamentMatchEnd
   s ->> d: tournamentMatchEnd
-  Note left of s: {roundID: 2, nextRoundID: 1, winner: 2}
+  Note left of s: {roundID: 2, nextRoundID: 1, winnerID: 2, participants: [...]}
 
   s ->> q: tournamentMatchStart
   s ->> m: tournamentMatchStart
@@ -103,5 +103,5 @@ sequenceDiagram
   s ->> q: tournamentMatchEnd
   s ->> m: tournamentMatchEnd
   s ->> d: tournamentMatchEnd
-  Note left of s: {roundID: 1, winner: 2}
+  Note left of s: {roundID: 1, winnerID: 2, participants: [...]}
 ```

--- a/src/server/lib/Round.ts
+++ b/src/server/lib/Round.ts
@@ -68,22 +68,13 @@ export default class Round {
       type: 'tournamentMatchEnd',
       roundID: this.id,
       nextRoundID: this.nextRoundID,
-      winner: winner
-        ? {
-            id: winner.userID,
-            username: winner.username,
-            avatar: winner.avatar,
-            score: winner.score,
-          }
-        : undefined,
-      losers: this._participants
-        .filter(participant => participant.userID !== winner?.userID)
-        .map(participant => ({
-          id: participant.userID,
-          username: participant.username,
-          avatar: participant.avatar,
-          score: participant.score,
-        })),
+      winnerID: winner?.userID,
+      participants: this._participants.map(participant => ({
+        id: participant.userID,
+        username: participant.username,
+        avatar: participant.avatar,
+        score: participant.score,
+      })),
       result: result,
     });
   }

--- a/src/server/types/Clients.d.ts
+++ b/src/server/types/Clients.d.ts
@@ -108,8 +108,8 @@ type ServerTunnelMessage =
       type: 'tournamentMatchEnd';
       roundID: number;
       nextRoundID?: number;
-      winner?: unknown;
-      losers;
+      winnerID?: number;
+      participants: unknown[];
       result?: 'cancel' | 'empty' | 'forfeit' | 'tie';
     }
   | {


### PR DESCRIPTION
This pull request updates the tournament match end event structure to simplify and standardize the way participant and winner information is represented. The main change is replacing separate `winner` and `losers` fields with a unified `participants` array and a `winnerID` field.

**Tournament match event structure update:**

* The tournament match end WebSocket event now uses a `winnerID` field and a unified `participants` array, removing the previous separate `winner` and `losers` fields for a more consistent data format. (`docs/WebSocket/README.md`, `src/server/lib/Round.ts`) [[1]](diffhunk://#diff-50f8a58f00f821245a06e75afe67c81e9e2adc7334490f716f79a1572c04faa8L330-R336) [[2]](diffhunk://#diff-7561b41489824775a02f02ac7d458aeddde8fa65be4c1243acea0e703cceca07L71-R72)