### PR TITLE
Add `newTournament` event

### DIFF
--- a/docs/WebSocket/README.md
+++ b/docs/WebSocket/README.md
@@ -248,6 +248,25 @@ Received when opponent makes a move in a match
 }
 ```
 
+### `newTournament`
+Received when a new tournament is created
+
+*Example:*
+```json
+{
+  "type": "newTournament",
+  "tournament": {
+    "id": 1,
+    "name": "Kittournament",
+    "participantCount": 1,
+    "owner": {
+      "id": 1,
+      "username": "user123",
+      "avatar": "/static/default_avatar.webp"
+    }
+  }
+}
+```
 
 ### `participantJoin`
 Received when a participant joins a tournament

--- a/src/server/lib/Tournament.ts
+++ b/src/server/lib/Tournament.ts
@@ -84,6 +84,21 @@ export class Tournament {
     this.server.game.players[participant.userID] = {match: this};
   }
 
+  public get() {
+    const owner = this.participants[0];
+
+    return {
+      id: this.id,
+      name: this.name,
+      participantCount: this.participants.length,
+      owner: {
+        id: owner.userID,
+        username: owner.username,
+        avatar: owner.avatar,
+      },
+    };
+  }
+
   private handleMessage =
     (participant: Participant) => async (data: RawData) => {
       let message;
@@ -103,9 +118,9 @@ export class Tournament {
       }
     };
 
-  public get owner() {
-    return this.participants[0];
-  }
+  // public get owner() {
+  //   return this.participants[0];
+  // }
 
   public removeClient(client: Client) {
     const participant = this.participants.find(
@@ -150,9 +165,9 @@ export class Tournament {
     }
   }
 
-  get participantCount() {
-    return this.participants.length;
-  }
+  // get participantCount() {
+  //   return this.participants.length;
+  // }
 
   private async start(participant: Participant) {
     if (this.round)

--- a/src/server/lib/Tournament.ts
+++ b/src/server/lib/Tournament.ts
@@ -118,10 +118,6 @@ export class Tournament {
       }
     };
 
-  // public get owner() {
-  //   return this.participants[0];
-  // }
-
   public removeClient(client: Client) {
     const participant = this.participants.find(
       participant => participant.socket === client.socket,
@@ -164,10 +160,6 @@ export class Tournament {
       Clients.sendClient(participant, message);
     }
   }
-
-  // get participantCount() {
-  //   return this.participants.length;
-  // }
 
   private async start(participant: Participant) {
     if (this.round)

--- a/src/server/lib/Tournaments.ts
+++ b/src/server/lib/Tournaments.ts
@@ -35,6 +35,8 @@ export default class Tournaments {
       type: 'success',
       origin: 'createTournament',
     });
+
+    return tournament;
   }
 
   public delete(id: number) {
@@ -42,16 +44,7 @@ export default class Tournaments {
   }
 
   public get() {
-    return Object.values(this.tournaments).map(tournament => ({
-      id: tournament.id,
-      name: tournament.name,
-      participantCount: tournament.participantCount,
-      owner: {
-        id: tournament.owner.userID,
-        username: tournament.owner.username,
-        avatar: tournament.owner.avatar,
-      },
-    }));
+    return Object.values(this.tournaments).map(tournament => tournament.get());
   }
 
   public join(id: number, participant: Player) {

--- a/src/server/lib/Tournaments.ts
+++ b/src/server/lib/Tournaments.ts
@@ -46,7 +46,11 @@ export default class Tournaments {
       id: tournament.id,
       name: tournament.name,
       participantCount: tournament.participantCount,
-      owner: {id: tournament.owner.userID},
+      owner: {
+        id: tournament.owner.userID,
+        username: tournament.owner.username,
+        avatar: tournament.owner.avatar,
+      },
     }));
   }
 

--- a/src/server/routes/api/tournaments/get.ts
+++ b/src/server/routes/api/tournaments/get.ts
@@ -1,37 +1,8 @@
 import {FastifyPluginAsync} from 'fastify';
-import SQL from 'sql-template-strings';
-import serializeUserAvatar from '#lib/serializeUserAvatar';
 
 const plugin: FastifyPluginAsync = async server => {
-  server.get('/', async (request, reply) => {
-    const tournaments = server.tournaments.get() as {owner: {id: number}}[];
-
-    let owners = [];
-
-    const ownerIDs = tournaments.map(tournament => tournament.owner.id);
-    if (ownerIDs.length > 0) {
-      const query = SQL`
-        SELECT id, username, has_avatar, avatar_version
-        FROM users
-        WHERE id IN (`;
-
-      for (const [index, id] of ownerIDs.entries()) {
-        if (index !== 0) query.append(SQL`, `);
-        query.append(SQL`${id}`);
-      }
-
-      query.append(SQL`)`);
-
-      owners = await server.db.all(query);
-      owners.forEach(serializeUserAvatar);
-    }
-
-    for (const tournament of tournaments) {
-      const owner = owners.find(owner => owner.id === tournament.owner.id);
-      if (owner) tournament.owner = owner;
-    }
-
-    return reply.send(tournaments);
+  server.get('/', (_request, reply) => {
+    return reply.send(server.tournaments.get());
   });
 };
 

--- a/src/server/tunnel/createTournament.ts
+++ b/src/server/tunnel/createTournament.ts
@@ -14,5 +14,15 @@ export default async function createTournament(
     });
 
   const player = await server.playerify(client);
-  server.tournaments.create(message.name, player);
+  const tournament = server.tournaments.create(message.name, player);
+
+  if (!tournament) return;
+
+  server.clients.broadcast(
+    {
+      type: 'newTournament',
+      tournament: tournament.get(),
+    },
+    [client.userID],
+  );
 }

--- a/src/server/types/Clients.d.ts
+++ b/src/server/types/Clients.d.ts
@@ -78,6 +78,10 @@ type ServerTunnelMessage =
       dy: number;
     }
   | {
+      type: 'newTournament';
+      tournament: unknown;
+    }
+  | {
       type: 'participantJoin';
       user: unknown;
     }


### PR DESCRIPTION
This pull request refactors how tournament data is structured and transmitted throughout the backend and WebSocket API, focusing on standardizing the tournament representation, simplifying the API logic, and introducing real-time tournament creation notifications. The changes improve maintainability and ensure consistent data shapes across the system.

**Tournament data structure and API simplification:**

* Refactored the `Tournament` class to provide a unified `get()` method that returns a standardized tournament object, including owner details, for API and broadcast use. Removed the `owner` and `participantCount` getters as their logic is now encapsulated in `get()`. [[1]](diffhunk://#diff-4921aec6c370869cd460fc1931ecc532baa263b119caa249df1ccfc95d8789b6R87-R101) [[2]](diffhunk://#diff-4921aec6c370869cd460fc1931ecc532baa263b119caa249df1ccfc95d8789b6L106-L109) [[3]](diffhunk://#diff-4921aec6c370869cd460fc1931ecc532baa263b119caa249df1ccfc95d8789b6L153-L156)
* Updated the `Tournaments.get()` method to use the new `Tournament.get()` method, ensuring all tournament lists have consistent, complete data.
* Simplified the `/api/tournaments` route to directly return the standardized tournament objects, removing the need for separate owner lookups and avatar serialization.

**WebSocket and real-time updates:**

* Added a new WebSocket message type, `newTournament`, which is broadcast to all clients (except the creator) when a tournament is created. The message includes the full tournament object. [[1]](diffhunk://#diff-50f8a58f00f821245a06e75afe67c81e9e2adc7334490f716f79a1572c04faa8R251-R269) [[2]](diffhunk://#diff-e3a4212879c97c0dca1b88053cbb9831df9dfe51cc4695346d5d73d3ed5fc067L17-R27)